### PR TITLE
Correct package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "preact-enzyme-adapter",
+  "name": "enzyme-adapter-preact",
   "version": "0.1.0",
   "description": "A Preact adapater for the Enzyme testing utility",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "author": "Brandon Dail",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Update `name` to match repo
Correct `main` to point to correct file

I opened this because the currently published package under 'enzyme-adapter-preact' does not work - the "main" points to a non-existent file: `"main": "lib/index.js",`